### PR TITLE
Export handle_write_pre function

### DIFF
--- a/lua/codeactions-on-save/init.lua
+++ b/lua/codeactions-on-save/init.lua
@@ -7,6 +7,7 @@ local main = require("codeactions-on-save.main")
 local inspect = require("codeactions-on-save.inspect")
 
 M.register = main.register
+M.handle_write_pre = main.handle_write_pre
 M.inspect = inspect.inspect
 
 return M

--- a/lua/codeactions-on-save/main.lua
+++ b/lua/codeactions-on-save/main.lua
@@ -59,6 +59,8 @@ local function handle_write_pre(kinds, buf, timeout_ms)
   end
 end
 
+M.handle_write_pre = handle_write_pre
+
 function M.register(pattern, kinds, timeout_ms)
   vim.api.nvim_create_autocmd("BufWritePre", {
     pattern = pattern,


### PR DESCRIPTION
Closes #4

Example of my usage:

```lua
local function LspOrgImports()
  local cos = require("codeactions-on-save")
  cos.handle_write_pre({ "source.organizeImports" }, 0, 1000)
end

local function LspFixAll()
  local cos = require("codeactions-on-save")
  cos.handle_write_pre({ "source.fixAll" }, 0, 1000)
end


local function lspAttach(bufnr, client)
 ...
   if client.server_capabilities.documentFormattingProvider then
    vim.api.nvim_buf_create_user_command(bufnr, 'LspFormat', function() vim.lsp.buf.format() end, {})
    vim.api.nvim_buf_create_user_command(bufnr, 'LspOrgImports', function() LspOrgImports() end, {})
    vim.api.nvim_buf_create_user_command(bufnr, 'LspToggleAutoFormat', function() LspToggleAutoFormat() end, {})
    vim.api.nvim_buf_create_user_command(bufnr, 'LspToggleAutoFormatBuffer', function() LspToggleAutoFormat() end, {})

    vim.api.nvim_create_augroup('CodeFormat', { clear = false })
    vim.api.nvim_create_autocmd({ 'BufWritePre' }, {
      group = 'CodeFormat',
      buffer = bufnr,
      desc = 'Format code on save',
      callback = function()
        -- Check if autoformatting is enabled
        if not IsLspAutoFormatEnabled() then
          return
        end
        LspOrgImports()
        vim.lsp.buf.format()
      end,
    })
  end


end
```